### PR TITLE
feat: Redesign profile page and header aesthetics

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,8 +26,10 @@
     <meta property="og:type" content="website" />
     <meta name="theme-color" content="#ff2d55" />
     <title>I heard this live</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Syne:wght@600;700;800&family=Outfit:wght@300;400;500;600&display=swap"
       rel="stylesheet"
     />
     <!-- Google tag (gtag.js) -->

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -17,265 +17,174 @@ export default function Header({ onAuthClick }) {
   };
 
   return (
-    <header
-      className="fixed top-4 left-1/2 -translate-x-1/2 w-[95%] max-w-2xl 
-                       backdrop-blur-md bg-white/10 dark:bg-gray-900/50
-                       rounded-2xl shadow-lg border border-white/20
-                       px-2 py-1 z-50
-                       transition-all duration-300 ease-in-out"
-    >
-      <div className="mx-auto px-4 h-16 flex items-center justify-between">
-        <h1
-          onClick={() => {
-            const currentPath = window.location.pathname;
-            const profilePath = `/${profile?.username || user.id}`;
-            if (currentPath === profilePath) {
-              navigate("/");
-            } else {
-              navigate(user ? profilePath : "/");
-            }
-          }}
-          className="cursor-pointer"
-        >
-          <span
-            className="hidden sm:block text-2xl font-bold font-display
-                       bg-gradient-to-r from-neon-pink to-neon-blue bg-clip-text text-transparent
-                       hover:from-neon-blue hover:to-neon-pink transition-all duration-500
-                       animate-gradient-x"
-          >
-            I heard this live
-          </span>
-          <span className="block sm:hidden leading-tight">
-            <span
-              className="text-lg font-bold font-display
-                         bg-gradient-to-r from-neon-pink to-neon-blue bg-clip-text text-transparent
-                         hover:from-neon-blue hover:to-neon-pink transition-all duration-500
-                         animate-gradient-x"
-            >
-              I heard this live
-            </span>
-          </span>
-        </h1>
-
-        {user ? (
-          <div className="flex items-center gap-2 sm:gap-4">
-            {isHomePage ? (
-              <button
-                onClick={() => navigate(`/${profile?.username || user.id}`)}
-                className="px-2 sm:px-4 py-2 border border-neon-blue text-neon-blue rounded-lg
-                         hover:bg-neon-blue/10 transition-colors duration-200
-                         flex items-center gap-2"
-              >
-                <svg
-                  className="w-4 h-4"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
-                  />
-                </svg>
-                <span className="hidden sm:inline">My Wall</span>
-              </button>
-            ) : (
-              <button
-                onClick={() => navigate("/")}
-                className="px-2 sm:px-4 py-2 border border-neon-blue text-neon-blue rounded-lg
-                         hover:bg-neon-blue/10 transition-colors duration-200
-                         flex items-center gap-2"
-              >
-                <svg
-                  className="w-4 h-4"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M12 4v16m8-8H4"
-                  />
-                </svg>
-                <span className="hidden sm:inline">Add concert</span>
-              </button>
-            )}
-
-            <Menu as="div" className="relative">
-              <Menu.Button
-                className="flex items-center gap-2 
-                                    hover:bg-dark-card/80 rounded-lg 
-                                    transition-colors duration-200"
-              >
-                <div className="w-10 h-10 rounded-full overflow-hidden border border-gray-700">
-                  <img
-                    src={
-                      profile?.avatar_url ||
-                      `https://ui-avatars.com/api/?name=${profile?.name}`
-                    }
-                    alt="Profile"
-                    className="w-full h-full object-cover"
-                  />
-                </div>
-                <div className="hidden items-center gap-2 px-3">
-                  <span className="text-sm text-gray-300">
-                    {profile?.username
-                      ? `@${profile.username}`
-                      : user.email.split("@")[0]}
-                  </span>
-                  <svg
-                    className="w-4 h-4 text-gray-400"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M19 9l-7 7-7-7"
-                    />
-                  </svg>
-                </div>
-              </Menu.Button>
-
-              <Menu.Items
-                className="absolute right-0 mt-2 w-56 bg-dark border border-gray-800 
-                                  rounded-lg shadow-lg overflow-hidden z-50"
-              >
-                <div className="px-4 py-3 border-b border-gray-800">
-                  <p className="text-sm text-gray-300 font-medium truncate">
-                    {profile?.username
-                      ? `@${profile.username}`
-                      : user.email.split("@")[0]}
-                  </p>
-                  <p className="text-xs text-gray-500 truncate">{user.email}</p>
-                </div>
-
-                <Menu.Item>
-                  {({ active }) => (
-                    <button
-                      onClick={() =>
-                        navigate(`/${profile?.username || user.id}`)
-                      }
-                      className={`${active ? "bg-gray-800" : ""
-                        } w-full text-left px-4 py-3 text-sm text-gray-300 flex items-center space-x-2`}
-                    >
-                      <svg
-                        className="w-4 h-4"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
-                        />
-                      </svg>
-                      <span>View My Wall</span>
-                    </button>
-                  )}
-                </Menu.Item>
-
-                <Menu.Item>
-                  {({ active }) => (
-                    <button
-                      onClick={() => navigate("/profile")}
-                      className={`${active ? "bg-gray-800" : ""
-                        } w-full text-left px-4 py-3 text-sm text-gray-300 flex items-center space-x-2`}
-                    >
-                      <svg
-                        className="w-4 h-4"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
-                        />
-                      </svg>
-                      <span>My Profile</span>
-                    </button>
-                  )}
-                </Menu.Item>
-
-                <Menu.Item>
-                  {({ active }) => (
-                    <a
-                      href="https://github.com/daytimedrinkingclub/iheardthis.live"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className={`${active ? "bg-gray-800" : ""
-                        } w-full text-left px-4 py-3 text-sm text-gray-300 flex items-center space-x-2`}
-                    >
-                      <svg
-                        className="w-4 h-4"
-                        fill="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          fillRule="evenodd"
-                          clipRule="evenodd"
-                          d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.87 8.17 6.84 9.5.5.08.66-.23.66-.5v-1.69c-2.77.6-3.36-1.34-3.36-1.34-.46-1.16-1.11-1.47-1.11-1.47-.91-.62.07-.6.07-.6 1 .07 1.53 1.03 1.53 1.03.87 1.52 2.34 1.07 2.91.83.09-.65.35-1.09.63-1.34-2.22-.25-4.55-1.11-4.55-4.92 0-1.11.38-2 1.03-2.71-.1-.25-.45-1.29.1-2.64 0 0 .84-.27 2.75 1.02.79-.22 1.65-.33 2.5-.33.85 0 1.71.11 2.5.33 1.91-1.29 2.75-1.02 2.75-1.02.55 1.35.2 2.39.1 2.64.65.71 1.03 1.6 1.03 2.71 0 3.82-2.34 4.66-4.57 4.91.36.31.69.92.69 1.85V21c0 .27.16.59.67.5C19.14 20.16 22 16.42 22 12A10 10 0 0012 2z"
-                        />
-                      </svg>
-                      <span>Star this project</span>
-                    </a>
-                  )}
-                </Menu.Item>
-                <Menu.Item>
-                  {({ active }) => (
-                    <button
-                      onClick={handleSignOut}
-                      className={`${active ? "bg-gray-800" : ""
-                        } w-full text-left px-4 py-3 text-sm text-gray-300 flex items-center space-x-2`}
-                    >
-                      <svg
-                        className="w-4 h-4"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"
-                        />
-                      </svg>
-                      <span>Log Out</span>
-                    </button>
-                  )}
-                </Menu.Item>
-              </Menu.Items>
-            </Menu>
-          </div>
-        ) : (
-          <button
+    <header className="fixed top-0 left-0 right-0 z-50">
+      <div className="backdrop-blur-xl bg-dark/40 border-b border-white/[0.04]">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 h-14 flex items-center justify-between">
+          {/* Logo */}
+          <h1
             onClick={() => {
-              if (window.location.pathname !== "/") {
+              const currentPath = window.location.pathname;
+              const profilePath = `/${profile?.username || user?.id}`;
+              if (currentPath === profilePath) {
                 navigate("/");
               } else {
-                onAuthClick();
+                navigate(user ? profilePath : "/");
               }
             }}
-            className="px-4 py-2 bg-neon-pink/20 border border-neon-pink 
-                     text-neon-pink rounded-lg hover:bg-neon-pink/30
-                     text-sm sm:text-base"
+            className="cursor-pointer select-none"
           >
-            Create My Wall
-          </button>
-        )}
+            <span className="text-sm font-display font-700 tracking-wide text-white/70 hover:text-white transition-colors duration-300">
+              iheardthis<span className="text-neon-pink/80">.live</span>
+            </span>
+          </h1>
+
+          {/* Right side */}
+          {user ? (
+            <div className="flex items-center gap-1">
+              {isHomePage ? (
+                <button
+                  onClick={() => navigate(`/${profile?.username || user.id}`)}
+                  className="px-3 py-1.5 text-xs font-sans font-500 text-gray-400
+                           hover:text-white transition-colors duration-200
+                           flex items-center gap-1.5"
+                >
+                  <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+                      d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
+                  </svg>
+                  My Wall
+                </button>
+              ) : (
+                <button
+                  onClick={() => navigate("/")}
+                  className="px-3 py-1.5 text-xs font-sans font-500 text-gray-400
+                           hover:text-white transition-colors duration-200
+                           flex items-center gap-1.5"
+                >
+                  <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 4v16m8-8H4" />
+                  </svg>
+                  Add concert
+                </button>
+              )}
+
+              <Menu as="div" className="relative">
+                <Menu.Button className="flex items-center rounded-full transition-colors duration-200 hover:ring-1 hover:ring-white/10">
+                  <div className="w-7 h-7 rounded-full overflow-hidden ring-1 ring-white/[0.08]">
+                    <img
+                      src={
+                        profile?.avatar_url ||
+                        `https://ui-avatars.com/api/?name=${profile?.name}`
+                      }
+                      alt="Profile"
+                      className="w-full h-full object-cover"
+                    />
+                  </div>
+                </Menu.Button>
+
+                <Menu.Items
+                  className="absolute right-0 mt-2 w-52 bg-dark-elevated backdrop-blur-2xl
+                            border border-white/[0.08] rounded-xl shadow-2xl shadow-black/40
+                            overflow-hidden z-50"
+                >
+                  <div className="px-3 py-2.5 border-b border-white/[0.06]">
+                    <p className="text-xs font-sans font-500 text-gray-300 truncate">
+                      {profile?.username
+                        ? `@${profile.username}`
+                        : user.email.split("@")[0]}
+                    </p>
+                    <p className="text-[10px] text-gray-600 truncate">{user.email}</p>
+                  </div>
+
+                  <div className="py-1">
+                    <MenuItem
+                      onClick={() => navigate(`/${profile?.username || user.id}`)}
+                      icon={<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />}
+                    >
+                      View My Wall
+                    </MenuItem>
+
+                    <MenuItem
+                      onClick={() => navigate("/profile")}
+                      icon={<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />}
+                    >
+                      My Profile
+                    </MenuItem>
+
+                    <MenuItemLink
+                      href="https://github.com/daytimedrinkingclub/iheardthis.live"
+                      icon={<path fillRule="evenodd" clipRule="evenodd" d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.87 8.17 6.84 9.5.5.08.66-.23.66-.5v-1.69c-2.77.6-3.36-1.34-3.36-1.34-.46-1.16-1.11-1.47-1.11-1.47-.91-.62.07-.6.07-.6 1 .07 1.53 1.03 1.53 1.03.87 1.52 2.34 1.07 2.91.83.09-.65.35-1.09.63-1.34-2.22-.25-4.55-1.11-4.55-4.92 0-1.11.38-2 1.03-2.71-.1-.25-.45-1.29.1-2.64 0 0 .84-.27 2.75 1.02.79-.22 1.65-.33 2.5-.33.85 0 1.71.11 2.5.33 1.91-1.29 2.75-1.02 2.75-1.02.55 1.35.2 2.39.1 2.64.65.71 1.03 1.6 1.03 2.71 0 3.82-2.34 4.66-4.57 4.91.36.31.69.92.69 1.85V21c0 .27.16.59.67.5C19.14 20.16 22 16.42 22 12A10 10 0 0012 2z" />}
+                      filled
+                    >
+                      Star this project
+                    </MenuItemLink>
+
+                    <div className="border-t border-white/[0.04] mt-1 pt-1">
+                      <MenuItem
+                        onClick={handleSignOut}
+                        icon={<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />}
+                      >
+                        Log Out
+                      </MenuItem>
+                    </div>
+                  </div>
+                </Menu.Items>
+              </Menu>
+            </div>
+          ) : !isHomePage ? (
+            <button
+              onClick={() => navigate("/")}
+              className="px-3.5 py-1.5 text-xs font-sans font-500
+                       text-neon-pink border border-neon-pink/30 rounded-full
+                       hover:bg-neon-pink/10 transition-all duration-300"
+            >
+              Create My Wall
+            </button>
+          ) : null}
+        </div>
       </div>
     </header>
+  );
+}
+
+function MenuItem({ onClick, icon, children }) {
+  return (
+    <Menu.Item>
+      {({ active }) => (
+        <button
+          onClick={onClick}
+          className={`${active ? "bg-white/[0.04]" : ""}
+            w-full text-left px-3 py-2 text-xs font-sans text-gray-400
+            flex items-center gap-2 transition-colors duration-150`}
+        >
+          <svg className="w-3.5 h-3.5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            {icon}
+          </svg>
+          {children}
+        </button>
+      )}
+    </Menu.Item>
+  );
+}
+
+function MenuItemLink({ href, icon, filled, children }) {
+  return (
+    <Menu.Item>
+      {({ active }) => (
+        <a
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={`${active ? "bg-white/[0.04]" : ""}
+            w-full text-left px-3 py-2 text-xs font-sans text-gray-400
+            flex items-center gap-2 transition-colors duration-150`}
+        >
+          <svg className="w-3.5 h-3.5 text-gray-500" fill={filled ? "currentColor" : "none"} stroke={filled ? "none" : "currentColor"} viewBox="0 0 24 24">
+            {icon}
+          </svg>
+          {children}
+        </a>
+      )}
+    </Menu.Item>
   );
 }

--- a/src/pages/PublicProfile.jsx
+++ b/src/pages/PublicProfile.jsx
@@ -97,7 +97,7 @@ export default function PublicProfile() {
 
       <div className="relative z-10">
         {/* ── Profile Header ── */}
-        <div className="sticky top-0 pt-20 z-20 backdrop-blur-xl bg-dark/60 border-b border-white/[0.06]">
+        <div className="sticky top-0 pt-16 z-20 backdrop-blur-xl bg-dark/60 border-b border-white/[0.06]">
           <div className="max-w-6xl mx-auto px-4 sm:px-6 py-6 sm:py-8">
             <div className="flex flex-col sm:flex-row items-center sm:items-start gap-5 sm:gap-7">
               {/* Avatar with glow ring */}

--- a/src/pages/PublicProfile.jsx
+++ b/src/pages/PublicProfile.jsx
@@ -1,29 +1,16 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useParams } from "react-router-dom";
 import { supabase } from "../lib/supabase";
-import { motion } from "framer-motion";
+import { motion, AnimatePresence } from "framer-motion";
 import WaveLoader from "../components/WaveLoader";
 import { toast } from "sonner";
-
-const gradientKeyframes = `
-  @keyframes gradient {
-    0% {
-      background-position: 0% 50%;
-    }
-    50% {
-      background-position: 100% 50%;
-    }
-    100% {
-      background-position: 0% 50%;
-    }
-  }
-`;
 
 export default function PublicProfile() {
   const { username } = useParams();
   const [profile, setProfile] = useState(null);
   const [experiences, setExperiences] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [sortBy, setSortBy] = useState("recent");
 
   useEffect(() => {
     loadProfileAndExperiences();
@@ -61,6 +48,31 @@ export default function PublicProfile() {
     }
   };
 
+  const sortedExperiences = useMemo(() => {
+    const sorted = [...experiences];
+    if (sortBy === "popular") {
+      sorted.sort(
+        (a, b) => (b.artist.followers || 0) - (a.artist.followers || 0)
+      );
+    }
+    // "recent" is already the default order from the query
+    return sorted;
+  }, [experiences, sortBy]);
+
+  const stats = useMemo(() => {
+    const uniqueGenres = new Set();
+    const uniqueEvents = new Set();
+    experiences.forEach((exp) => {
+      if (exp.event_name) uniqueEvents.add(exp.event_name);
+      exp.artist.genres?.forEach((g) => uniqueGenres.add(g));
+    });
+    return {
+      artists: experiences.length,
+      events: uniqueEvents.size,
+      genres: uniqueGenres.size,
+    };
+  }, [experiences]);
+
   const handleCopyProfileLink = () => {
     const url = `${window.location.origin}/${profile.username}`;
     navigator.clipboard
@@ -73,311 +85,332 @@ export default function PublicProfile() {
   if (!profile) {
     return (
       <div className="min-h-screen flex items-center justify-center">
-        <p className="text-gray-400">Profile not found</p>
+        <p className="text-gray-400 font-sans">Profile not found</p>
       </div>
     );
   }
 
   return (
-    <>
-      <style>{gradientKeyframes}</style>
-      <div className="min-h-screen animated-gradient">
-        {/* Add noise texture */}
-        <div className="noise" />
+    <div className="min-h-screen animated-gradient">
+      <div className="noise" />
+      <div className="absolute inset-0 bg-black/30 backdrop-blur-[2px] z-0" />
 
-        {/* Add a subtle overlay */}
-        <div className="absolute inset-0 bg-black/30 backdrop-blur-[2px] z-0" />
-
-        {/* Wrap existing content in a relative container */}
-        <div className="relative z-10">
-          {/* Profile Header */}
-          <div className="sticky top-0 pt-20 z-20 backdrop-blur-md bg-dark/30 border-b border-gray-800/50">
-            <div className="container mx-auto px-4 py-8">
-              <div className="flex items-start gap-6">
-                {/* Avatar */}
-                <motion.img
-                  initial={{ scale: 0.5, opacity: 0 }}
-                  animate={{ scale: 1, opacity: 1 }}
-                  transition={{ duration: 0.5 }}
+      <div className="relative z-10">
+        {/* ── Profile Header ── */}
+        <div className="sticky top-0 pt-20 z-20 backdrop-blur-xl bg-dark/60 border-b border-white/[0.06]">
+          <div className="max-w-6xl mx-auto px-4 sm:px-6 py-6 sm:py-8">
+            <div className="flex flex-col sm:flex-row items-center sm:items-start gap-5 sm:gap-7">
+              {/* Avatar with glow ring */}
+              <motion.div
+                initial={{ scale: 0.5, opacity: 0 }}
+                animate={{ scale: 1, opacity: 1 }}
+                transition={{ duration: 0.5, ease: [0.22, 1, 0.36, 1] }}
+                className="relative shrink-0"
+              >
+                <div className="absolute -inset-1 rounded-full bg-gradient-to-br from-neon-pink via-neon-pink/40 to-neon-blue opacity-60 blur-md" />
+                <img
                   src={
                     profile.avatar_url ||
                     `https://ui-avatars.com/api/?name=${profile.name}`
                   }
                   alt={profile.name}
-                  className="w-24 h-24 rounded-full object-cover"
+                  className="relative w-20 h-20 sm:w-24 sm:h-24 rounded-full object-cover ring-2 ring-white/10"
                 />
+              </motion.div>
 
-                {/* Profile Info */}
-                <div className="flex-1 space-y-4">
-                  {/* Name and Username Row */}
-                  <div className="flex items-center gap-3 flex-wrap">
-                    <motion.h1
-                      initial={{ y: -20, opacity: 0 }}
-                      animate={{ y: 0, opacity: 1 }}
-                      transition={{ delay: 0.2 }}
-                      className="text-3xl font-bold text-white"
-                    >
-                      {profile.name}
-                    </motion.h1>
-                    <motion.button
-                      initial={{ y: -20, opacity: 0 }}
+              {/* Info block */}
+              <div className="flex-1 min-w-0 text-center sm:text-left space-y-3">
+                {/* Name row */}
+                <div className="flex flex-col sm:flex-row items-center sm:items-center gap-2 sm:gap-3">
+                  <motion.h1
+                    initial={{ y: -16, opacity: 0 }}
+                    animate={{ y: 0, opacity: 1 }}
+                    transition={{ delay: 0.15 }}
+                    className="text-2xl sm:text-3xl font-display font-800 text-white tracking-tight"
+                  >
+                    {profile.name}
+                  </motion.h1>
+
+                  <motion.button
+                    initial={{ y: -16, opacity: 0 }}
+                    animate={{ y: 0, opacity: 1 }}
+                    transition={{ delay: 0.25 }}
+                    onClick={handleCopyProfileLink}
+                    className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full
+                               bg-white/[0.04] border border-white/[0.08]
+                               hover:border-neon-pink/50 hover:bg-neon-pink/[0.06]
+                               text-gray-400 hover:text-neon-pink
+                               transition-all duration-300 text-sm font-sans"
+                  >
+                    <span>@{profile.username}</span>
+                    <svg className="w-3.5 h-3.5 opacity-40" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                    </svg>
+                  </motion.button>
+
+                  {profile.country && (
+                    <motion.span
+                      initial={{ y: -16, opacity: 0 }}
                       animate={{ y: 0, opacity: 1 }}
                       transition={{ delay: 0.3 }}
-                      onClick={handleCopyProfileLink}
-                      className="px-3 py-1 rounded-full bg-dark-card border border-gray-700
-                               hover:border-neon-pink hover:text-neon-pink
-                               transition-colors duration-200 text-gray-300 text-sm
-                               flex items-center gap-2"
-                    >
-                      <span>@{profile.username}</span>
-                    </motion.button>
-                  </div>
-
-                  {/* Country Row */}
-                  {profile.country && (
-                    <motion.p
-                      initial={{ y: -20, opacity: 0 }}
-                      animate={{ y: 0, opacity: 1 }}
-                      transition={{ delay: 0.4 }}
-                      className="flex items-center gap-2 text-gray-400"
+                      className="flex items-center gap-1.5 text-gray-500 text-sm"
                     >
                       <img
                         src={`https://flagcdn.com/24x18/${profile.country.toLowerCase()}.png`}
                         alt={profile.country}
-                        className="w-5 rounded"
+                        className="w-4 rounded-sm"
                       />
-                      <span>
-                        {new Intl.DisplayNames(["en"], { type: "region" }).of(
-                          profile.country
-                        )}
-                      </span>
-                    </motion.p>
+                      {new Intl.DisplayNames(["en"], { type: "region" }).of(
+                        profile.country
+                      )}
+                    </motion.span>
                   )}
-
-                  {/* Social Links Row */}
-                  <motion.div
-                    initial={{ y: -20, opacity: 0 }}
-                    animate={{ y: 0, opacity: 1 }}
-                    transition={{ delay: 0.5 }}
-                    className="flex flex-wrap gap-4"
-                  >
-                    {profile.spotify_url && (
-                      <a
-                        href={profile.spotify_url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="p-2 rounded-lg bg-dark-card border border-gray-700 
-                                 hover:border-[#1DB954] hover:text-[#1DB954] text-gray-400 
-                                 transition-colors duration-200"
-                      >
-                        <svg
-                          className="w-5 h-5"
-                          viewBox="0 0 24 24"
-                          fill="currentColor"
-                        >
-                          <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z" />
-                        </svg>
-                      </a>
-                    )}
-
-                    {profile.soundcloud_url && (
-                      <a
-                        href={profile.soundcloud_url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="p-2 rounded-lg bg-dark-card border border-gray-700 
-                                 hover:border-[#ff5500] hover:text-[#ff5500] text-gray-400 
-                                 transition-colors duration-200"
-                      >
-                        <svg
-                          className="w-5 h-5 text-gray-400"
-                          viewBox="0 0 24 24"
-                          fill="currentColor"
-                        >
-                          <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm7.17 12.89c-.06 1.07-.95 1.9-2.02 1.9h-4.86c-.22 0-.4-.18-.4-.4V9.1c0-.2.12-.37.27-.43 0 0 .45-.31 1.39-.31.57 0 1.12.15 1.64.45.75.44 1.3 1.15 1.52 2.11.16-.03.33-.07.52-.07.6 0 1.16.25 1.4.59.55.58.58 1.4.54 1.45zm-7.89-3.42c.15 1.77.25 3.39 0 5.16a.16.16 0 01-.31 0c-.24-1.75-.14-3.4 0-5.16a.16.16 0 01.31 0zm-.98 5.16a.17.17 0 01-.33 0 19.71 19.71 0 010-4.55.17.17 0 01.33 0v4.55zm-.98-4.7c.16 1.62.23 3.08 0 4.7a.16.16 0 01-.32 0c-.22-1.6-.15-3.1 0-4.7a.16.16 0 01.32 0zm-.99 4.7a.16.16 0 01-.32 0 16.65 16.65 0 010-4.25.16.16 0 01.32 0v4.25zm-.98-3.19c.25 1.1.14 2.08-.01 3.2a.15.15 0 01-.3 0c-.14-1.11-.25-2.1-.01-3.2a.16.16 0 01.32 0zm-.98-.17c.23 1.13.15 2.09-.01 3.22a.16.16 0 01-.32 0c-.14-1.12-.21-2.1-.01-3.22a.17.17 0 01.34 0zm-.99.55c.24.75.16 1.36-.01 2.13a.16.16 0 01-.31 0c-.14-.76-.2-1.38-.01-2.13a.17.17 0 01.33 0z" />
-                        </svg>
-                      </a>
-                    )}
-
-                    {profile.twitter_url && (
-                      <a
-                        href={profile.twitter_url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="p-2 rounded-lg bg-dark-card border border-gray-700 
-                                 hover:border-[#1DA1F2] hover:text-[#1DA1F2] text-gray-400 
-                                 transition-colors duration-200"
-                      >
-                        <svg
-                          className="w-5 h-5"
-                          viewBox="0 0 24 24"
-                          fill="currentColor"
-                        >
-                          <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
-                        </svg>
-                      </a>
-                    )}
-
-                    {profile.youtube_url && (
-                      <a
-                        href={profile.youtube_url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="p-2 rounded-lg bg-dark-card border border-gray-700 
-                                 hover:border-[#FF0000] hover:text-[#FF0000] text-gray-400 
-                                 transition-colors duration-200"
-                      >
-                        <svg
-                          className="w-5 h-5"
-                          viewBox="0 0 24 24"
-                          fill="currentColor"
-                        >
-                          <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z" />
-                        </svg>
-                      </a>
-                    )}
-                  </motion.div>
                 </div>
+
+                {/* Stats row */}
+                <motion.div
+                  initial={{ y: -12, opacity: 0 }}
+                  animate={{ y: 0, opacity: 1 }}
+                  transition={{ delay: 0.35 }}
+                  className="flex items-center justify-center sm:justify-start gap-5 text-sm"
+                >
+                  <div className="flex items-center gap-1.5">
+                    <span className="font-display font-700 text-white">{stats.artists}</span>
+                    <span className="text-gray-500">artists</span>
+                  </div>
+                  <div className="w-px h-3 bg-white/10" />
+                  <div className="flex items-center gap-1.5">
+                    <span className="font-display font-700 text-white">{stats.events}</span>
+                    <span className="text-gray-500">events</span>
+                  </div>
+                  <div className="w-px h-3 bg-white/10" />
+                  <div className="flex items-center gap-1.5">
+                    <span className="font-display font-700 text-white">{stats.genres}</span>
+                    <span className="text-gray-500">genres</span>
+                  </div>
+                </motion.div>
+
+                {/* Social links */}
+                <motion.div
+                  initial={{ y: -12, opacity: 0 }}
+                  animate={{ y: 0, opacity: 1 }}
+                  transition={{ delay: 0.4 }}
+                  className="flex items-center justify-center sm:justify-start gap-2"
+                >
+                  {profile.spotify_url && (
+                    <SocialLink href={profile.spotify_url} hoverColor="hover:border-[#1DB954] hover:text-[#1DB954] hover:bg-[#1DB954]/[0.08]">
+                      <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+                        <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z" />
+                      </svg>
+                    </SocialLink>
+                  )}
+                  {profile.soundcloud_url && (
+                    <SocialLink href={profile.soundcloud_url} hoverColor="hover:border-[#ff5500] hover:text-[#ff5500] hover:bg-[#ff5500]/[0.08]">
+                      <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+                        <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm7.17 12.89c-.06 1.07-.95 1.9-2.02 1.9h-4.86c-.22 0-.4-.18-.4-.4V9.1c0-.2.12-.37.27-.43 0 0 .45-.31 1.39-.31.57 0 1.12.15 1.64.45.75.44 1.3 1.15 1.52 2.11.16-.03.33-.07.52-.07.6 0 1.16.25 1.4.59.55.58.58 1.4.54 1.45zm-7.89-3.42c.15 1.77.25 3.39 0 5.16a.16.16 0 01-.31 0c-.24-1.75-.14-3.4 0-5.16a.16.16 0 01.31 0zm-.98 5.16a.17.17 0 01-.33 0 19.71 19.71 0 010-4.55.17.17 0 01.33 0v4.55zm-.98-4.7c.16 1.62.23 3.08 0 4.7a.16.16 0 01-.32 0c-.22-1.6-.15-3.1 0-4.7a.16.16 0 01.32 0zm-.99 4.7a.16.16 0 01-.32 0 16.65 16.65 0 010-4.25.16.16 0 01.32 0v4.25zm-.98-3.19c.25 1.1.14 2.08-.01 3.2a.15.15 0 01-.3 0c-.14-1.11-.25-2.1-.01-3.2a.16.16 0 01.32 0zm-.98-.17c.23 1.13.15 2.09-.01 3.22a.16.16 0 01-.32 0c-.14-1.12-.21-2.1-.01-3.22a.17.17 0 01.34 0zm-.99.55c.24.75.16 1.36-.01 2.13a.16.16 0 01-.31 0c-.14-.76-.2-1.38-.01-2.13a.17.17 0 01.33 0z" />
+                      </svg>
+                    </SocialLink>
+                  )}
+                  {profile.twitter_url && (
+                    <SocialLink href={profile.twitter_url} hoverColor="hover:border-white/30 hover:text-white hover:bg-white/[0.06]">
+                      <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+                        <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+                      </svg>
+                    </SocialLink>
+                  )}
+                  {profile.youtube_url && (
+                    <SocialLink href={profile.youtube_url} hoverColor="hover:border-[#FF0000] hover:text-[#FF0000] hover:bg-[#FF0000]/[0.08]">
+                      <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+                        <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z" />
+                      </svg>
+                    </SocialLink>
+                  )}
+                </motion.div>
               </div>
             </div>
           </div>
+        </div>
 
-          {/* Artist Grid */}
-          <div className="container mx-auto px-4 py-8">
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-              {experiences.map((experience, index) => (
-                <motion.div
+        {/* ── Sort Bar ── */}
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 pt-6 pb-2">
+          <motion.div
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.5 }}
+            className="flex items-center justify-between"
+          >
+            <h2 className="text-xs font-sans font-500 uppercase tracking-[0.15em] text-gray-500">
+              Artist Wall
+            </h2>
+            <div className="flex items-center bg-white/[0.04] rounded-full p-0.5 border border-white/[0.06]">
+              <SortButton active={sortBy === "recent"} onClick={() => setSortBy("recent")}>
+                Recent
+              </SortButton>
+              <SortButton active={sortBy === "popular"} onClick={() => setSortBy("popular")}>
+                Popular
+              </SortButton>
+            </div>
+          </motion.div>
+        </div>
+
+        {/* ── Artist Grid ── */}
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 py-4 pb-16">
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3 sm:gap-4">
+            <AnimatePresence mode="popLayout">
+              {sortedExperiences.map((experience, index) => (
+                <ArtistCard
                   key={experience.id}
-                  initial={{ opacity: 0, y: 20 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ delay: index * 0.1 }}
-                  className="relative aspect-square group rounded-xl overflow-hidden 
-                            border border-gray-800/50 hover:border-neon-pink/50
-                            transition-all duration-500 hover:shadow-lg hover:shadow-neon-pink/20
-                            cursor-pointer"
-                  onClick={() =>
-                    window.open(experience.artist.spotify_url, "_blank")
-                  }
-                >
-                  {/* Background Image with Gradient */}
-                  <div className="absolute inset-0">
-                    <img
-                      src={experience.artist.image_url}
-                      alt={experience.artist.name}
-                      className="w-full h-full object-cover transition-transform duration-700 
-                               group-hover:scale-110 brightness-90"
-                    />
-                    <div
-                      className="absolute inset-0 bg-gradient-to-t 
-                                  from-black via-black/50 to-transparent
-                                  opacity-60 group-hover:opacity-90
-                                  transition-opacity duration-500"
-                    />
-                  </div>
-
-                  {/* Content Overlay */}
-                  <div className="absolute inset-0 p-6 flex flex-col justify-end">
-                    {/* Artist Info Container - Moves up on hover */}
-                    <div
-                      className="transform translate-y-0 group-hover:-translate-y-4 
-                                  transition-all duration-500 ease-out"
-                    >
-                      {/* Artist Name - Always visible */}
-                      <div className="flex items-center gap-2 mb-2">
-                        <h3
-                          className="font-bold text-xl text-white 
-                                     group-hover:text-neon-pink transition-colors"
-                        >
-                          {experience.artist.name}
-                        </h3>
-                        <svg
-                          className="w-4 h-4 text-gray-400 group-hover:text-neon-pink 
-                                   opacity-0 group-hover:opacity-100 transition-all duration-500 
-                                   transform translate-x-2 group-hover:translate-x-0"
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth={2}
-                            d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
-                          />
-                        </svg>
-                      </div>
-
-                      {/* Additional Info - Hidden initially, shows on hover */}
-                      <div
-                        className="h-0 group-hover:h-auto overflow-hidden opacity-0 
-                                    group-hover:opacity-100 transition-all duration-500
-                                    transform translate-y-4 group-hover:translate-y-0
-                                    ease-[cubic-bezier(0.34,1.56,0.64,1)]"
-                      >
-                        <div className="space-y-2">
-                          <p className="text-sm text-gray-300 flex items-center gap-2">
-                            <svg
-                              className="w-4 h-4"
-                              fill="currentColor"
-                              viewBox="0 0 24 24"
-                            >
-                              <path d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-                            </svg>
-                            {experience.artist.followers?.toLocaleString()}{" "}
-                            followers
-                          </p>
-
-                          {experience.event_name && (
-                            <p className="text-neon-pink flex items-center gap-2">
-                              <svg
-                                className="w-4 h-4"
-                                fill="currentColor"
-                                viewBox="0 0 24 24"
-                              >
-                                <path d="M18 10.5V8.75C18 8.06 17.44 7.5 16.75 7.5H16.5V6.25C16.5 5.56 15.94 5 15.25 5H4.75C4.06 5 3.5 5.56 3.5 6.25V10.5L2.25 12V13H3.5V17.75C3.5 18.44 4.06 19 4.75 19H15.25C15.94 19 16.5 18.44 16.5 17.75V13H17.75V12L16.5 10.5H18ZM15 17.5H5V6.5H15V17.5ZM7.5 8.5H12.5V10H7.5V8.5ZM7.5 11.5H12.5V13H7.5V11.5ZM7.5 14.5H12.5V16H7.5V14.5Z" />
-                              </svg>
-                              {experience.event_name}
-                            </p>
-                          )}
-
-                          {experience.city && (
-                            <p className="text-gray-400 text-sm flex items-center gap-2">
-                              <svg
-                                className="w-4 h-4"
-                                fill="currentColor"
-                                viewBox="0 0 24 24"
-                              >
-                                <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z" />
-                              </svg>
-                              {experience.city}
-                            </p>
-                          )}
-
-                          {/* Genres */}
-                          <div className="flex flex-wrap gap-2 mt-3">
-                            {experience.artist.genres
-                              ?.slice(0, 2)
-                              .map((genre) => (
-                                <span
-                                  key={genre}
-                                  className="inline-block px-2 py-1 text-xs rounded-full 
-                                         bg-neon-blue/10 text-neon-blue border border-neon-blue/20
-                                         backdrop-blur-sm"
-                                >
-                                  {genre}
-                                </span>
-                              ))}
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </motion.div>
+                  experience={experience}
+                  index={index}
+                />
               ))}
+            </AnimatePresence>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ── Sub-components ── */
+
+function SocialLink({ href, hoverColor, children }) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={`p-2 rounded-lg bg-white/[0.03] border border-white/[0.06]
+                 text-gray-500 transition-all duration-300 ${hoverColor}`}
+    >
+      {children}
+    </a>
+  );
+}
+
+function SortButton({ active, onClick, children }) {
+  return (
+    <button
+      onClick={onClick}
+      className={`px-3.5 py-1.5 rounded-full text-xs font-sans font-500 transition-all duration-300
+        ${
+          active
+            ? "bg-neon-pink/15 text-neon-pink shadow-[inset_0_0_0_1px_rgba(255,45,85,0.25)]"
+            : "text-gray-500 hover:text-gray-300"
+        }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function ArtistCard({ experience, index }) {
+  return (
+    <motion.div
+      layout
+      initial={{ opacity: 0, scale: 0.95 }}
+      animate={{ opacity: 1, scale: 1 }}
+      exit={{ opacity: 0, scale: 0.95 }}
+      transition={{ delay: Math.min(index * 0.04, 0.8), duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
+      className="relative aspect-square group rounded-xl overflow-hidden
+                 border border-white/[0.06] hover:border-neon-pink/40
+                 transition-all duration-500 hover:shadow-[0_8px_40px_-12px_rgba(255,45,85,0.25)]
+                 cursor-pointer"
+      onClick={() => window.open(experience.artist.spotify_url, "_blank")}
+    >
+      {/* Background Image */}
+      <div className="absolute inset-0">
+        <img
+          src={experience.artist.image_url}
+          alt={experience.artist.name}
+          className="w-full h-full object-cover transition-transform duration-700
+                     group-hover:scale-110 brightness-[0.85] group-hover:brightness-100"
+        />
+        <div
+          className="absolute inset-0 bg-gradient-to-t
+                      from-black/80 via-black/20 via-50% to-transparent
+                      transition-opacity duration-500"
+        />
+      </div>
+
+      {/* Content Overlay */}
+      <div className="absolute inset-0 p-4 sm:p-5 flex flex-col justify-end">
+        {/* Smooth gradient backdrop that intensifies on hover */}
+        <div className="absolute inset-x-0 bottom-0 h-full
+                        bg-gradient-to-t from-black via-black/60 via-40% to-transparent
+                        opacity-0 group-hover:opacity-100 transition-opacity duration-500 rounded-b-xl" />
+        <div className="relative transform translate-y-0 group-hover:-translate-y-2 transition-all duration-500 ease-out">
+          {/* Artist Name */}
+          <div className="flex items-center gap-1.5 mb-1">
+            <h3
+              className="font-display font-700 text-base sm:text-lg text-white leading-tight
+                         group-hover:text-neon-pink transition-colors duration-300"
+            >
+              {experience.artist.name}
+            </h3>
+            <svg
+              className="w-3.5 h-3.5 text-gray-400 group-hover:text-neon-pink
+                       opacity-0 group-hover:opacity-100 transition-all duration-500
+                       transform translate-x-1 group-hover:translate-x-0 shrink-0"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+            </svg>
+          </div>
+
+          {/* Hover details */}
+          <div
+            className="h-0 group-hover:h-auto overflow-hidden opacity-0
+                        group-hover:opacity-100 transition-all duration-500
+                        transform translate-y-3 group-hover:translate-y-0"
+          >
+            <div className="space-y-1.5 pt-1">
+              {experience.artist.followers > 0 && (
+                <p className="text-xs text-gray-400 flex items-center gap-1.5 font-sans">
+                  <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+                  </svg>
+                  {experience.artist.followers?.toLocaleString()} followers
+                </p>
+              )}
+
+              {experience.event_name && (
+                <p className="text-xs text-neon-pink font-sans font-500 flex items-center gap-1.5">
+                  <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3" />
+                  </svg>
+                  {experience.event_name}
+                </p>
+              )}
+
+              {experience.city && (
+                <p className="text-xs text-gray-500 flex items-center gap-1.5 font-sans">
+                  <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z" />
+                  </svg>
+                  {experience.city}
+                </p>
+              )}
+
+              {experience.artist.genres?.length > 0 && (
+                <div className="flex flex-wrap gap-1.5 pt-1">
+                  {experience.artist.genres.slice(0, 2).map((genre) => (
+                    <span
+                      key={genre}
+                      className="inline-block px-2 py-0.5 text-[10px] rounded-full font-sans
+                               bg-neon-blue/[0.08] text-neon-blue/80 border border-neon-blue/[0.12]"
+                    >
+                      {genre}
+                    </span>
+                  ))}
+                </div>
+              )}
             </div>
           </div>
         </div>
       </div>
-    </>
+    </motion.div>
   );
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,8 +10,10 @@ module.exports = {
       colors: {
         'neon-pink': '#ff2d55',
         'neon-blue': '#0ff',
-        'dark': '#121212',
+        'amber': '#f59e0b',
+        'dark': '#0e0e10',
         'dark-card': 'rgba(16, 16, 16, 0.6)',
+        'dark-elevated': 'rgba(24, 24, 28, 0.8)',
       },
       keyframes: {
         soundwave: {
@@ -45,8 +47,8 @@ module.exports = {
         'gradient-x': 'gradient-x 15s ease infinite',
       },
       fontFamily: {
-        sans: ['Space Grotesk', 'system-ui', 'sans-serif'],
-        display: ['Space Grotesk', 'system-ui', 'sans-serif'],
+        sans: ['Outfit', 'system-ui', 'sans-serif'],
+        display: ['Syne', 'system-ui', 'sans-serif'],
       },
     },
   },


### PR DESCRIPTION
## Summary
- **Typography**: Replaced Space Grotesk with Syne (display) + Outfit (body) for distinctive music-forward feel
- **Profile page**: Avatar glow ring, stats bar (artists/events/genres), sorting controls (Recent/Popular), 2-column mobile grid, smoother hover gradients on artist cards
- **Header**: Slim full-width bar with minimal "iheardthis.live" logo, refined dropdown menu, hide CTA button on homepage
- **Colors**: Added amber accent and dark-elevated surface color, warmer dark base

## Test plan
- [ ] Verify profile page loads at `/:username` with stats, sort controls, and artist grid
- [ ] Test sort toggle switches between Recent and Popular ordering
- [ ] Check mobile layout renders 2-column grid
- [ ] Verify hover state on artist cards shows readable text with smooth gradient
- [ ] Confirm header shows logo-only on homepage, logo + CTA on other pages
- [ ] Test logged-in header shows nav buttons and avatar dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)